### PR TITLE
chore: bump json5 from 2.1.3 to 2.2.3 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "aws4-axios": "^1.12.0",
     "axios": "^0.21.1",
     "fhir-works-on-aws-interface": "^2.0.0",
+    "json5": "^2.2.3",
     "mime-types": "^2.1.26"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,6 +2896,11 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
x dependabot json5 alert

Issue #, if available:

Description of changes:
update json5 dependency to 2.2.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.